### PR TITLE
Try some better variable names

### DIFF
--- a/lib/rules/no-unexpected-multiline.js
+++ b/lib/rules/no-unexpected-multiline.js
@@ -23,15 +23,17 @@ module.exports = function(context) {
      * @private
      */
     function checkForBreakAfter(node, msg) {
-        var paren = context.getTokenAfter(node);
-        var beforeParen = node;
-        while (paren.value === ")") {
-            beforeParen = paren;
-            paren = context.getTokenAfter(paren);
+        var nodeExpressionEnd = node;
+        var openParen = context.getTokenAfter(node);
+
+        // Move along until the end of the wrapped expression
+        while (openParen.value === ")") {
+            nodeExpressionEnd = openParen;
+            openParen = context.getTokenAfter(nodeExpressionEnd);
         }
 
-        if (paren.loc.start.line !== beforeParen.loc.end.line) {
-            context.report(node, paren.loc.start, msg, { char: paren.value });
+        if (openParen.loc.start.line !== nodeExpressionEnd.loc.end.line) {
+            context.report(node, openParen.loc.start, msg, { char: openParen.value });
         }
     }
 


### PR DESCRIPTION
We're checking opening and closing parens these days, so `paren` isn't a particularly good name imo.

Hows this?